### PR TITLE
Fix dropped logs on unhandled exceptions

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ def handle_uncaught_exception(exc_type, exc_value, exc_traceback):
     logger.opt(exception=(exc_type, exc_value, exc_traceback)).error(
         "Неперехваченное исключение"
     )
+    logger.complete()
 
 sys.excepthook = handle_uncaught_exception
 


### PR DESCRIPTION
Fixes an issue where error logs were occasionally lost or not written fully when the application crashed because `loguru`'s background thread (created by using `enqueue=True`) did not finish processing before the process abruptly terminated. Adding `logger.complete()` to the `handle_uncaught_exception` function ensures the logging queue is flushed on crash.