### PR TITLE
fix: make loguru write logs synchronously

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ from modules.worker import TransactionWorker
 
 system = System()
 config_data = system.config
-logger.add(system.log_file, rotation="1 MB", enqueue=True)
+logger.add(system.log_file, rotation="1 MB")
 
 
 def handle_uncaught_exception(exc_type, exc_value, exc_traceback):


### PR DESCRIPTION
Fixed the logging issue where messages were delayed or lost by making loguru write logs synchronously. Removed the `enqueue=True` parameter from the logger configuration in `main.py`.