### PR TITLE
Add GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libxcb-cursor0
+
+      - name: Prepare requirements
+        run: |
+          iconv -f UTF-16LE -t UTF-8 requirements.txt > req_utf8.txt
+          grep -v -E 'pypiwin32|pywin32|win32_setctime' req_utf8.txt > requirements_linux.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_linux.txt
+          pip install pytest pytest-qt pytest-cov pytest-mock
+
+      - name: Run tests
+        env:
+          DB_PASSWORD: dummy
+          DB_USER: dummy
+          DB_NAME: dummy
+          DB_HOST: dummy
+        run: |
+          xvfb-run -a python -m pytest -p no:pytest-qt tests/


### PR DESCRIPTION
Sets up CI/CD pipeline in GitHub using Actions to run tests automatically. Converts requirements file and filters out Windows-specific libraries allowing headless UI testing in an Ubuntu environment.