### PR TITLE
Fix loguru sync log writing

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ from modules.worker import TransactionWorker
 
 system = System()
 config_data = system.config
-logger.add(system.log_file, rotation="1 MB", enqueue=True)
+logger.add(system.log_file, rotation="1 MB")
 
 
 def handle_uncaught_exception(exc_type, exc_value, exc_traceback):


### PR DESCRIPTION
The issue of log entries not appearing immediately and error logs sometimes being lost when the application crashes is due to `enqueue=True` in the Loguru configuration in `main.py`. This delegates log writing to a background queue thread. On a crash, the queue can be destroyed before all logs are written. 

Removing `enqueue=True` forces synchronous logging, resolving the issue.

---
*PR created automatically by Jules for task [1192009880228468761](https://jules.google.com/task/1192009880228468761) started by @MarcusStill*