### PR TITLE
Apply lightweight Windows 10/11 styling to GUI

### DIFF
--- a/files/style.qss
+++ b/files/style.qss
@@ -1,0 +1,270 @@
+/* Основа приложения */
+QWidget {
+    font-family: "Segoe UI", "San Francisco", "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
+    background-color: #F3F3F3; /* Светло-серый фон как в Win11 */
+    color: #1F1F1F; /* Темный текст для контраста */
+}
+
+/* Кнопки */
+QPushButton {
+    background-color: #FFFFFF;
+    border: 1px solid #CCCCCC;
+    border-radius: 6px;
+    padding: 6px 16px;
+    min-height: 24px;
+}
+QPushButton:hover {
+    background-color: #F6F6F6;
+    border: 1px solid #B0B0B0;
+}
+QPushButton:pressed {
+    background-color: #E0E0E0;
+    border: 1px solid #909090;
+}
+QPushButton:checked {
+    background-color: #E0E0E0;
+}
+QPushButton:disabled {
+    background-color: #F0F0F0;
+    color: #A0A0A0;
+    border: 1px solid #E0E0E0;
+}
+
+/* Поля ввода (LineEdit) */
+QLineEdit {
+    background-color: #FFFFFF;
+    border: 1px solid #E5E5E5;
+    border-bottom: 2px solid #E5E5E5; /* Акцентная линия снизу для Fluent Design */
+    border-radius: 4px;
+    padding: 6px;
+    selection-background-color: #0078D4;
+}
+QLineEdit:hover {
+    background-color: #FAFAFA;
+}
+QLineEdit:focus {
+    border-bottom: 2px solid #0078D4; /* Синий акцент при фокусе */
+    background-color: #FFFFFF;
+}
+QLineEdit:disabled {
+    background-color: #F9F9F9;
+    color: #A0A0A0;
+}
+
+/* Комбобоксы (Выпадающие списки) */
+QComboBox {
+    background-color: #FFFFFF;
+    border: 1px solid #E5E5E5;
+    border-bottom: 2px solid #E5E5E5;
+    border-radius: 4px;
+    padding: 5px;
+    padding-left: 10px;
+}
+QComboBox:hover {
+    background-color: #FAFAFA;
+}
+QComboBox:focus {
+    border-bottom: 2px solid #0078D4;
+}
+QComboBox::drop-down {
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: 25px;
+    border-left-width: 0px;
+}
+QComboBox QAbstractItemView {
+    border: 1px solid #E5E5E5;
+    selection-background-color: #E0EEF9; /* Легкий синий фон при выделении */
+    selection-color: #1F1F1F;
+    background-color: #FFFFFF;
+}
+
+/* Таблицы (QTableWidget / QTableView) */
+QTableView {
+    background-color: #FFFFFF;
+    border: 1px solid #E5E5E5;
+    border-radius: 4px;
+    gridline-color: #E0E0E0;
+    selection-background-color: #E0EEF9;
+    selection-color: #1F1F1F;
+    alternate-background-color: #F9F9F9;
+}
+QHeaderView::section {
+    background-color: #F3F3F3;
+    color: #1F1F1F;
+    padding: 6px;
+    border: 0px;
+    border-right: 1px solid #E0E0E0;
+    border-bottom: 1px solid #E0E0E0;
+    font-weight: bold;
+}
+QHeaderView::section:first {
+    border-top-left-radius: 4px;
+}
+QHeaderView::section:last {
+    border-top-right-radius: 4px;
+    border-right: 0px;
+}
+
+/* Вкладки (QTabWidget) */
+QTabWidget::pane {
+    border: 1px solid #E5E5E5;
+    background: #FFFFFF;
+    border-radius: 4px;
+}
+QTabBar::tab {
+    background: #F3F3F3;
+    border: 1px solid transparent;
+    padding: 8px 16px;
+    margin-right: 2px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+QTabBar::tab:selected {
+    background: #FFFFFF;
+    border: 1px solid #E5E5E5;
+    border-bottom-color: #FFFFFF; /* Сливается с панелью */
+    border-bottom: 2px solid #0078D4; /* Акцент на активную вкладку */
+}
+QTabBar::tab:hover:!selected {
+    background: #EAEAEA;
+}
+
+/* Группбоксы (QGroupBox) */
+QGroupBox {
+    border: 1px solid #E5E5E5;
+    border-radius: 6px;
+    margin-top: 15px;
+    background-color: #FFFFFF;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    left: 10px;
+    padding: 0 5px;
+    color: #555555;
+}
+
+/* Чекбоксы и радио-кнопки */
+QCheckBox, QRadioButton {
+    spacing: 8px;
+}
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 18px;
+    height: 18px;
+    background-color: #FFFFFF;
+    border: 1px solid #CCCCCC;
+}
+QCheckBox::indicator {
+    border-radius: 4px;
+}
+QRadioButton::indicator {
+    border-radius: 9px;
+}
+QCheckBox::indicator:hover, QRadioButton::indicator:hover {
+    border: 1px solid #0078D4;
+}
+QCheckBox::indicator:checked, QRadioButton::indicator:checked {
+    background-color: #0078D4;
+    border: 1px solid #0078D4;
+}
+QCheckBox::indicator:disabled, QRadioButton::indicator:disabled {
+    background-color: #F0F0F0;
+    border: 1px solid #E0E0E0;
+}
+
+/* Спинбоксы и поля даты */
+QSpinBox, QDoubleSpinBox, QDateEdit, QDateTimeEdit {
+    background-color: #FFFFFF;
+    border: 1px solid #E5E5E5;
+    border-bottom: 2px solid #E5E5E5;
+    border-radius: 4px;
+    padding: 4px;
+    selection-background-color: #0078D4;
+}
+QSpinBox:hover, QDoubleSpinBox:hover, QDateEdit:hover, QDateTimeEdit:hover {
+    background-color: #FAFAFA;
+}
+QSpinBox:focus, QDoubleSpinBox:focus, QDateEdit:focus, QDateTimeEdit:focus {
+    border-bottom: 2px solid #0078D4;
+}
+
+/* Скроллбары */
+QScrollBar:vertical {
+    border: none;
+    background: #F3F3F3;
+    width: 10px;
+    margin: 0px 0 0px 0;
+    border-radius: 5px;
+}
+QScrollBar::handle:vertical {
+    background: #CCCCCC;
+    min-height: 20px;
+    border-radius: 5px;
+}
+QScrollBar::handle:vertical:hover {
+    background: #999999;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    border: none;
+    background: none;
+}
+QScrollBar:horizontal {
+    border: none;
+    background: #F3F3F3;
+    height: 10px;
+    margin: 0px 0 0px 0;
+    border-radius: 5px;
+}
+QScrollBar::handle:horizontal {
+    background: #CCCCCC;
+    min-width: 20px;
+    border-radius: 5px;
+}
+QScrollBar::handle:horizontal:hover {
+    background: #999999;
+}
+QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
+    border: none;
+    background: none;
+}
+
+/* Прогресс бары */
+QProgressBar {
+    border: 1px solid #E5E5E5;
+    border-radius: 4px;
+    background-color: #FFFFFF;
+    text-align: center;
+    color: #1F1F1F;
+}
+QProgressBar::chunk {
+    background-color: #0078D4;
+    border-radius: 3px;
+}
+
+/* Меню */
+QMenuBar {
+    background-color: #F3F3F3;
+    border-bottom: 1px solid #E5E5E5;
+}
+QMenuBar::item {
+    padding: 6px 10px;
+    background: transparent;
+}
+QMenuBar::item:selected {
+    background: #EAEAEA;
+    border-radius: 4px;
+}
+QMenu {
+    background-color: #FFFFFF;
+    border: 1px solid #CCCCCC;
+    border-radius: 4px;
+}
+QMenu::item {
+    padding: 6px 20px 6px 20px;
+}
+QMenu::item:selected {
+    background-color: #E0EEF9;
+    color: #1F1F1F;
+}

--- a/main.py
+++ b/main.py
@@ -3556,6 +3556,14 @@ class Payment:
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     app.setStyle("Fusion")
+
+    style_path = os.path.join("files", "style.qss")
+    try:
+        with open(style_path, "r", encoding="utf-8") as f:
+            app.setStyleSheet(f.read())
+    except Exception as e:
+        logger.error(f"Не удалось загрузить стили: {e}")
+
     auth = AuthForm()
     auth.show()
     auth.ui.label_9.setText(system.database)


### PR DESCRIPTION
Added `files/style.qss` containing lightweight styling rules inspired by Fluent Design, and updated `main.py` to load and apply it, respecting the existing "Fusion" style base.

---
*PR created automatically by Jules for task [6673537598745447017](https://jules.google.com/task/6673537598745447017) started by @MarcusStill*